### PR TITLE
feat: upgrade Selenium API to 4.33.0 and bump version to 1.2.23_cloud

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 dependencies {
     implementation 'org.projectlombok:lombok:1.18.20'
     implementation 'org.seleniumhq.selenium:selenium-api:4.33.0'
-    implementation 'io.appium:java-client:9.2.2'
+    implementation 'io.appium:java-client:9.4.0'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.apache.maven.plugins:maven-toolchains-plugin:3.0.0'
     implementation 'org.testng:testng:7.4.0'
@@ -39,7 +39,7 @@ dependencies {
 }
 
 group = 'com.testsigma'
-version = '1.2.23_cloud'
+version = '1.2.24_cloud'
 description = 'testsigma-addon-archetype'
 java.sourceCompatibility = JavaVersion.VERSION_11
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ repositories {
 
 dependencies {
     implementation 'org.projectlombok:lombok:1.18.20'
-    implementation 'org.seleniumhq.selenium:selenium-api:4.20.0'
+    implementation 'org.seleniumhq.selenium:selenium-api:4.33.0'
     implementation 'io.appium:java-client:9.2.2'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.apache.maven.plugins:maven-toolchains-plugin:3.0.0'
@@ -39,7 +39,7 @@ dependencies {
 }
 
 group = 'com.testsigma'
-version = '1.2.22_cloud'
+version = '1.2.23_cloud'
 description = 'testsigma-addon-archetype'
 java.sourceCompatibility = JavaVersion.VERSION_11
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ RELEASE_SIGNING_ENABLED=true
 
 GROUP=com.testsigma
 POM_ARTIFACT_ID=testsigma-addon-archetype
-VERSION_NAME=1.2.22_cloud
+VERSION_NAME=1.2.23_cloud
 
 POM_NAME=Testsigma Addon Archetype
 POM_DESCRIPTION=Testsigma Addon Archetype

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ RELEASE_SIGNING_ENABLED=true
 
 GROUP=com.testsigma
 POM_ARTIFACT_ID=testsigma-addon-archetype
-VERSION_NAME=1.2.23_cloud
+VERSION_NAME=1.2.24_cloud
 
 POM_NAME=Testsigma Addon Archetype
 POM_DESCRIPTION=Testsigma Addon Archetype

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <testsigma.sdk.version>1.2.23_cloud</testsigma.sdk.version>
+        <testsigma.sdk.version>1.2.24_cloud</testsigma.sdk.version>
         <junit.jupiter.version>5.8.0-M1</junit.jupiter.version>
         <testsigma.addon.maven.plugin>1.0.0</testsigma.addon.maven.plugin>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <testsigma.sdk.version>1.2.22_cloud</testsigma.sdk.version>
+        <testsigma.sdk.version>1.2.23_cloud</testsigma.sdk.version>
         <junit.jupiter.version>5.8.0-M1</junit.jupiter.version>
         <testsigma.addon.maven.plugin>1.0.0</testsigma.addon.maven.plugin>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>


### PR DESCRIPTION
- Upgrade Selenium API dependency from 4.20.0 to 4.33.0 for improved compatibility and latest features
- Bump project version from 1.2.22_cloud to 1.2.23_cloud
- Update version references across build.gradle, gradle.properties, and archetype pom.xml

This update ensures the archetype uses the latest stable Selenium API version and maintains version consistency across all configuration files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Selenium and Appium dependency versions.
  * Increased project version to 1.2.24_cloud across configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->